### PR TITLE
fix: 시간대로 인해 동일해야 할 키 값이 다른 문제

### DIFF
--- a/frontend/app/admin/orders/page.tsx
+++ b/frontend/app/admin/orders/page.tsx
@@ -14,7 +14,10 @@ const getBatchDate = (dateStr: string) => {
     if (date.getHours() >= 14) {
         batchDate.setDate(date.getDate() + 1);
     }
-    return batchDate.toISOString().split('T')[0];
+    const year = batchDate.getFullYear();
+    const month = String(batchDate.getMonth() + 1).padStart(2, '0');
+    const day = String(batchDate.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
 };
 
 export default function Orders() {


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
#63 주문 합배송으로 보여주는 로직 수정
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
원하는 로직 (KST 기준):
[전날 14:00 ~ 당일 13:59:59] 주문을 하나의 키(당일 날짜)로 묶고 싶다.
예: 3월 24일 14:00 ~ 3월 25일 13:59 → 모두 2026-03-25라는 키로 생성.

현재 코드의 문제점:
date.getHours()는 로직상 로컬 시간(KST, UTC+9)을 기준으로 14시를 체크합니다. 여기까지는 괜찮습니다.
하지만 마지막에 toISOString()을 호출하는 순간, 이 시간은 UTC(영국 시간)로 변환됩니다.
한국 시간(KST)으로 오전 00:00 ~ 08:59 사이라면, UTC로 변환했을 때 날짜가 하루 전으로 돌아가 버립니다. (9시간 차이 때문)

결과적으로 발생하는 현상:
똑같이 "오늘 14시 전"인 주문들이라도:
오전 09:00 ~ 13:59 사이 주문: toISOString()을 해도 날짜가 오늘로 유지됨.
오전 00:00 ~ 08:59 사이 주문: toISOString()을 하면 날짜가 어제로 찍힘.
결국 같은 배치(Batch)여야 할 주문들이 09시를 기점으로 키가 갈라지게 됩니다.

연 월 일을 바로 접근해 문제를 해결하였습니다.